### PR TITLE
Improve error messaging when browser binary not found

### DIFF
--- a/src/cmd/launch_profile.rs
+++ b/src/cmd/launch_profile.rs
@@ -27,7 +27,7 @@ pub fn process_cmd_launch_profile(context: &AppContext,
             ForkBrowserProcError::BadExitCode => NativeResponse::error_with_dbg_msg("Failed to launch browser with new profile (bad exit code)!", e),
             ForkBrowserProcError::ForkError { .. } => NativeResponse::error_with_dbg_msg("Failed to launch browser with new profile (fork error)!", e),
             ForkBrowserProcError::ProcessLaunchError(_) => NativeResponse::error_with_dbg_msg("Failed to launch browser with new profile!", e),
-            ForkBrowserProcError::BinaryNotFound => NativeResponse::error_with_dbg_msg("Unable to find browser binary!", e),
+            ForkBrowserProcError::BinaryNotFound(_) => NativeResponse::error_with_dbg_msg("Unable to find browser binary!", e),
             ForkBrowserProcError::BinaryDoesNotExist => NativeResponse::error(concat!(
             "The version of your browser that is currently running can no longer be found. ",
             "This is usually because your browser has updated but you haven't restarted your browser recently to apply the update. ",

--- a/src/process.rs
+++ b/src/process.rs
@@ -30,7 +30,7 @@ pub enum ForkBrowserProcError {
     ForkError { error_message: String },
     ProcessLaunchError(io::Error),
     MSIXProcessLaunchError { error_message: String },
-    BinaryNotFound,
+    BinaryNotFound(String),
     BinaryDoesNotExist,
     COMError { error_message: String }
 }
@@ -80,7 +80,7 @@ pub fn fork_browser_proc(app_state: &AppState, profile: &ProfileEntry, url: Opti
         Some(v) => v,
         None => match get_parent_proc_path() {
             Ok(v) => v,
-            Err(_) => return Err(ForkBrowserProcError::BinaryNotFound)
+            Err(e) => return Err(ForkBrowserProcError::BinaryNotFound(format!("{:?}", e)))
         }
     };
 


### PR DESCRIPTION
Allows distinction between several possible causes of the error

Should help diagnose what's going on in https://github.com/null-dev/firefox-profile-switcher-connector/issues/14 (I am experiencing the same issue)